### PR TITLE
fix: add semantic release config

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,44 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: true
+
+# Always validate all commits, and ignore the PR title
+# commitsOnly: true
+
+# Always validate the PR title AND all the commits
+# titleAndCommits: true
+
+# Require at least one commit to be valid
+# this is only relevant when using commitsOnly: true or titleAndCommits: true,
+# which validate all commits by default
+# anyCommit: true
+
+# You can define a list of valid scopes
+# scopes:
+#   - scope1
+#   - scope2
+#   ...
+
+# By default types specified in commitizen/conventional-commit-types is used.
+# See: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json
+# You can override the valid types
+# types:
+#   - feat
+#   - fix
+#   - docs
+#   - style
+#   - refactor
+#   - perf
+#   - test
+#   - build
+#   - ci
+#   - chore
+#   - revert
+
+# Allow use of Merge commits (eg on github: "Merge branch 'master' into feature/ride-unicorns")
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+# allowMergeCommits: true
+
+# Allow use of Revert commits (eg on github: "Revert "feat: ride unicorns"")
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+# allowRevertCommits: true
+


### PR DESCRIPTION
This should be a `ci:` commit but I’m forcing a patch version release because it hasn’t published via semantic version yet.